### PR TITLE
Add oplog timestamps to up / down output

### DIFF
--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -4,6 +4,7 @@ const status = require("./status");
 const config = require("../env/config");
 const migrationsDir = require("../env/migrationsDir");
 const lock = require("../utils/lock");
+const oplog = require("../utils/oplog")
 
 module.exports = async (db, client) => {
   const downgraded = [];
@@ -38,12 +39,16 @@ module.exports = async (db, client) => {
       const migration = await migrationsDir.loadMigration(manualMigrationFileToApply || lastAppliedItem.file);
       const {down} = migration;
 
+      console.info('Database oplog before migrating down:', await oplog.getCurrentTimestamp(client))
+
       if (context) {
         const ctx = await context({ migrationFile: fileName, operation: 'down' })
         await down(db, client, ctx);
       } else {
         await down(db, client, {});
       }
+
+      console.info('Database oplog after migrating down:', await oplog.getCurrentTimestamp(client))
 
     } catch (err) {
       if (!manualMigrationFileToApply) {

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -7,6 +7,7 @@ const config = require("../env/config");
 const migrationsDir = require("../env/migrationsDir");
 const getName = require('../utils/name');
 const lock = require("../utils/lock");
+const oplog = require("../utils/oplog")
 
 module.exports = async (db, client) => {
   const statusItems = await status(db);
@@ -48,12 +49,16 @@ module.exports = async (db, client) => {
       const migration = await migrationsDir.loadMigration(item.file);
       const { up } = migration;
 
+      console.info('Database oplog before migrating up:', await oplog.getCurrentTimestamp(client))
+
       if (context) {
         const ctx = await context({ migrationFile: item.file, operation: 'up' })
         await up(db, client, ctx);
       } else {
         await up(db, client, {});
       }
+
+      console.info('Database oplog after migrating up:', await oplog.getCurrentTimestamp(client))
 
     } catch (err) {
       const error = new Error(

--- a/lib/utils/oplog.js
+++ b/lib/utils/oplog.js
@@ -1,0 +1,9 @@
+async function getCurrentTimestamp(client) {
+    const localDb = client.db('local');
+    const oplog = await localDb.collection('oplog.rs').find({}, { projection: { ts: 1, _id: 0 } }).sort({ $natural: -1 }).limit(1).toArray();
+    return oplog[0].ts;
+  }
+
+module.exports = {
+    getCurrentTimestamp,
+}

--- a/lib/utils/oplog.js
+++ b/lib/utils/oplog.js
@@ -1,4 +1,8 @@
 async function getCurrentTimestamp(client) {
+    if (!client || !client.db) {
+        return null;
+    }
+
     const localDb = client.db('local');
     const oplog = await localDb.collection('oplog.rs').find({}, { projection: { ts: 1, _id: 0 } }).sort({ $natural: -1 }).limit(1).toArray();
     return oplog[0].ts;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "migrate-mongo-alt",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "migrate-mongo-alt",
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-mongo-alt",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "A database migration tool for MongoDB in Node",
   "main": "lib/migrate-mongo.js",
   "bin": {


### PR DESCRIPTION
This prints oplog timestamps, which is useful for MongoDB Atlas point-in-time restores. In the event of a faulty migration, this will allow us to restore the database to the exact last possible moment.

![Screenshot 2024-07-10 at 4 15 09 PM](https://github.com/theogravity/migrate-mongo-alt/assets/5410234/b72b87d0-09fc-4840-a385-49bacd1ab83e)

![Screenshot 2024-07-10 at 4 17 55 PM](https://github.com/theogravity/migrate-mongo-alt/assets/5410234/b2d25ad1-e294-46e0-81ac-e45086021a23)

##### Checklist

- [x] `npm test` passes and has 100% coverage
