### PR TITLE
Handle empty oplog

### DIFF
--- a/lib/utils/oplog.js
+++ b/lib/utils/oplog.js
@@ -5,7 +5,7 @@ async function getCurrentTimestamp(client) {
 
     const localDb = client.db('local');
     const oplog = await localDb.collection('oplog.rs').find({}, { projection: { ts: 1, _id: 0 } }).sort({ $natural: -1 }).limit(1).toArray();
-    return oplog[0].ts;
+    return oplog[0]?.ts || "No current / previous oplog";
   }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "migrate-mongo-alt",
-  "version": "12.0.2",
+  "version": "12.0.3",
   "description": "A database migration tool for MongoDB in Node",
   "main": "lib/migrate-mongo.js",
   "bin": {


### PR DESCRIPTION
Fixes a bug introduced with oplog printing that would cause a crash in the event of an empty oplog (such as a brand new database)

##### Checklist

- [x] `npm test` passes and has 100% coverage
